### PR TITLE
feat: Implement Level, Player, and initial World/Chunk structure

### DIFF
--- a/core/src/main/java/com/example/engine/entities/Player.java
+++ b/core/src/main/java/com/example/engine/entities/Player.java
@@ -1,0 +1,59 @@
+package com.example.engine.entities;
+
+import com.badlogic.gdx.math.Vector3;
+
+public class Player {
+    private Vector3 position;
+    // Potentially add a Camera field later if player manages its own camera
+    // private com.badlogic.gdx.graphics.PerspectiveCamera playerCamera;
+
+    public Player(float x, float y, float z) {
+        this.position = new Vector3(x, y, z);
+        // If we were to use a player-specific camera:
+        // this.playerCamera = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+        // this.playerCamera.position.set(x, y, z);
+        // this.playerCamera.lookAt(x, y - 1, z -1 ); // Example lookAt
+        // this.playerCamera.near = 0.1f;
+        // this.playerCamera.far = 300f;
+        // this.playerCamera.update();
+    }
+
+    public Vector3 getPosition() {
+        return position;
+    }
+
+    public void setPosition(float x, float y, float z) {
+        this.position.set(x, y, z);
+        // if (playerCamera != null) {
+        //     playerCamera.position.set(x,y,z);
+        //     // Update lookAt direction or other camera params if needed
+        //     playerCamera.update();
+        // }
+    }
+
+    public void setPosition(Vector3 newPosition) {
+        this.position.set(newPosition);
+        // if (playerCamera != null) {
+        //     playerCamera.position.set(newPosition);
+        //     playerCamera.update();
+        // }
+    }
+
+    // public com.badlogic.gdx.graphics.PerspectiveCamera getPlayerCamera() {
+    //    return playerCamera;
+    // }
+
+    public void update(float deltaTime) {
+        // Movement logic will go here in the future
+        // For example:
+        // if (Gdx.input.isKeyPressed(Input.Keys.W)) {
+        //     position.add(0, 0, -PLAYER_SPEED * deltaTime);
+        // }
+        // ...etc.
+
+        // if (playerCamera != null) {
+        //     // Ensure camera follows player or is updated based on player's orientation
+        //     playerCamera.update();
+        // }
+    }
+}

--- a/core/src/main/java/com/example/engine/world/Level.java
+++ b/core/src/main/java/com/example/engine/world/Level.java
@@ -1,0 +1,45 @@
+package com.example.engine.world;
+
+import com.example.engine.entities.Player; // Import the Player class
+// No Gdx import needed directly unless for Gdx.app.log or similar, which we might add later.
+
+public class Level {
+    private World world;
+    private Player player;
+
+    public Level() {
+        this.world = new World(); // Assumes World() constructor is suitable (it is, based on current World.java)
+
+        // Sensible default starting position for the player
+        // e.g., slightly above the center of a potential initial ground level in a chunk
+        float playerStartX = Chunk.CHUNK_SIZE_X / 2.0f;
+        float playerStartY = (Chunk.CHUNK_SIZE_Y / 2.0f) + 2.0f; // A bit above the default ground
+        float playerStartZ = Chunk.CHUNK_SIZE_Z / 2.0f;
+        this.player = new Player(playerStartX, playerStartY, playerStartZ);
+    }
+
+    public World getWorld() {
+        return world;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public void update(float deltaTime) {
+        // Update player (e.g., for future movement input)
+        player.update(deltaTime);
+
+        // Update world (e.g., rebuild meshes for chunks that have changed)
+        world.updateDirtyChunks();
+    }
+
+    // Consider adding a dispose method if Level manages disposable resources directly in the future
+    // For now, World and Player (if it had disposables) would be disposed by MyEngine or whoever owns Level.
+    // public void dispose() {
+    //     world.dispose();
+    //     // if (player instanceof com.badlogic.gdx.utils.Disposable) {
+    //     // ((com.badlogic.gdx.utils.Disposable)player).dispose();
+    //     // }
+    // }
+}

--- a/core/src/main/java/com/example/engine/world/World.java
+++ b/core/src/main/java/com/example/engine/world/World.java
@@ -39,6 +39,63 @@ public class World implements Disposable {
         return chunks;
     }
 
+    public Voxel getVoxel(int worldX, int worldY, int worldZ) {
+        int chunkX = Math.floorDiv(worldX, Chunk.CHUNK_SIZE_X);
+        int chunkY = Math.floorDiv(worldY, Chunk.CHUNK_SIZE_Y);
+        int chunkZ = Math.floorDiv(worldZ, Chunk.CHUNK_SIZE_Z);
+
+        Chunk chunk = getChunk(chunkX, chunkY, chunkZ);
+        if (chunk == null) {
+            return null; // Or return a static AIR Voxel instance
+        }
+
+        int localX = Math.floorMod(worldX, Chunk.CHUNK_SIZE_X);
+        int localY = Math.floorMod(worldY, Chunk.CHUNK_SIZE_Y);
+        int localZ = Math.floorMod(worldZ, Chunk.CHUNK_SIZE_Z);
+
+        return chunk.getVoxel(localX, localY, localZ);
+    }
+
+    public void setVoxel(int worldX, int worldY, int worldZ, Voxel.VoxelType type) {
+        int chunkX = Math.floorDiv(worldX, Chunk.CHUNK_SIZE_X);
+        int chunkY = Math.floorDiv(worldY, Chunk.CHUNK_SIZE_Y);
+        int chunkZ = Math.floorDiv(worldZ, Chunk.CHUNK_SIZE_Z);
+
+        // Ensure chunk exists, create if not.
+        // The existing createChunk method in World.java can be used or adapted.
+        // It currently takes chunk coordinates.
+        String chunkKey = getChunkKey(chunkX, chunkY, chunkZ);
+        if (!chunks.containsKey(chunkKey)) {
+            createChunk(chunkX, chunkY, chunkZ);
+        }
+
+        Chunk chunk = getChunk(chunkX, chunkY, chunkZ);
+        // It's possible createChunk failed or returned null, though current implementation doesn't show that.
+        // However, a null check is robust.
+        if (chunk == null) {
+            Gdx.app.error("World", "Failed to get or create chunk at " + chunkX + ", " + chunkY + ", " + chunkZ);
+            return;
+        }
+
+        int localX = Math.floorMod(worldX, Chunk.CHUNK_SIZE_X);
+        int localY = Math.floorMod(worldY, Chunk.CHUNK_SIZE_Y);
+        int localZ = Math.floorMod(worldZ, Chunk.CHUNK_SIZE_Z);
+
+        chunk.setVoxel(localX, localY, localZ, type);
+    }
+
+    public void clearVoxel(int worldX, int worldY, int worldZ) {
+        setVoxel(worldX, worldY, worldZ, Voxel.VoxelType.AIR);
+    }
+
+    public void updateDirtyChunks() {
+        for (Chunk chunk : chunks.values()) {
+            if (chunk != null) { // Good practice to check for null, though map shouldn't store them.
+                chunk.rebuildMeshAndDataTextureIfNeeded();
+            }
+        }
+    }
+
     @Override
     public void dispose() {
         for (Chunk chunk : chunks.values()) {

--- a/core/src/test/java/com/example/engine/world/WorldTest.java
+++ b/core/src/test/java/com/example/engine/world/WorldTest.java
@@ -1,0 +1,126 @@
+package com.example.engine.world;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.backends.headless.HeadlessApplication;
+import com.badlogic.gdx.graphics.GL20;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.mockito.Mockito;
+
+// Basic GDX headless setup for tests
+class HeadlessGdxGame implements ApplicationListener {
+    @Override public void create() {}
+    @Override public void resize(int width, int height) {}
+    @Override public void render() {}
+    @Override public void pause() {}
+    @Override public void resume() {}
+    @Override public void dispose() {}
+}
+
+public class WorldTest {
+
+    private static Application application;
+
+    @BeforeAll
+    public static void setUpGdx() {
+        // Initialize a headless GDX environment.
+        application = new HeadlessApplication(new HeadlessGdxGame());
+        // Mock Gdx.gl and Gdx.gl30 if necessary for deeper engine parts,
+        // For Chunk's createDataTexture, GL30 is used.
+        Gdx.gl = Mockito.mock(GL20.class);
+        // Mock Gdx.gl30. Important for Chunk.createDataTexture()
+        Gdx.gl30 = Mockito.mock(com.badlogic.gdx.graphics.GL30.class);
+    }
+
+    @AfterAll
+    public static void tearDownGdx() {
+        if (application != null) {
+            application.exit();
+            application = null;
+        }
+        Gdx.gl = null;
+        Gdx.gl30 = null;
+    }
+
+    @Test
+    public void testSetAndGetVoxel() {
+        World world = new World();
+        // Test within the initial chunk area (e.g. 0,0,0 to 15,15,15 for a 16x16x16 chunk)
+        // These coordinates should hit one of the default chunks created by World constructor.
+        world.setVoxel(1, 1, 1, Voxel.VoxelType.DIRT);
+        Voxel voxel = world.getVoxel(1, 1, 1);
+        Assertions.assertNotNull(voxel, "Voxel should not be null after setting.");
+        Assertions.assertEquals(Voxel.VoxelType.DIRT, voxel.type, "Voxel type should be DIRT.");
+
+        world.setVoxel(1, 1, 1, Voxel.VoxelType.STONE);
+        voxel = world.getVoxel(1, 1, 1);
+        Assertions.assertNotNull(voxel);
+        Assertions.assertEquals(Voxel.VoxelType.STONE, voxel.type, "Voxel type should be STONE after updating.");
+    }
+
+    @Test
+    public void testClearAndGetVoxel() {
+        World world = new World();
+        world.setVoxel(2, 2, 2, Voxel.VoxelType.GRASS); // Set something first
+        world.clearVoxel(2, 2, 2); // Clear it (sets to AIR)
+        Voxel voxel = world.getVoxel(2, 2, 2);
+        Assertions.assertNotNull(voxel, "Voxel should not be null after clearing.");
+        Assertions.assertEquals(Voxel.VoxelType.AIR, voxel.type, "Voxel type should be AIR after clearing.");
+    }
+
+    @Test
+    public void testSetAndGetVoxelNegativeCoordinates() {
+        World world = new World();
+        // This should fall into a new chunk, e.g., chunk (-1, -1, -1)
+        world.setVoxel(-5, -5, -5, Voxel.VoxelType.STONE);
+        Voxel voxel = world.getVoxel(-5, -5, -5);
+        Assertions.assertNotNull(voxel, "Voxel at negative coordinates should not be null after setting.");
+        Assertions.assertEquals(Voxel.VoxelType.STONE, voxel.type, "Voxel type at negative coordinates should be STONE.");
+    }
+
+    @Test
+    public void testGetVoxelInUnloadedChunk() {
+        World world = new World();
+        // World constructor might create some initial chunks, but let's pick coords far away
+        Voxel voxel = world.getVoxel(Chunk.CHUNK_SIZE_X * 100, Chunk.CHUNK_SIZE_Y * 100, Chunk.CHUNK_SIZE_Z * 100);
+        // Based on current World.getVoxel, it returns null if chunk doesn't exist.
+        Assertions.assertNull(voxel, "Voxel in an unloaded/non-existent chunk should be null.");
+    }
+
+    @Test
+    public void testSetVoxelCreatesChunk() {
+        World world = new World();
+        // Calculate chunk coordinates for a voxel far away that wouldn't exist by default
+        int farX = Chunk.CHUNK_SIZE_X * 10; // Beyond default worldRadius of 2
+        int farY = Chunk.CHUNK_SIZE_Y * 10;
+        int farZ = Chunk.CHUNK_SIZE_Z * 10;
+
+        int chunkX = Math.floorDiv(farX, Chunk.CHUNK_SIZE_X);
+        int chunkY = Math.floorDiv(farY, Chunk.CHUNK_SIZE_Y);
+        int chunkZ = Math.floorDiv(farZ, Chunk.CHUNK_SIZE_Z);
+
+        // Ensure chunk does not exist initially
+        Assertions.assertNull(world.getChunk(chunkX, chunkY, chunkZ),
+            "Chunk at (" + chunkX + "," + chunkY + "," + chunkZ + ") should not exist before setting voxel far away.");
+
+        // Set a voxel there
+        world.setVoxel(farX, farY, farZ, Voxel.VoxelType.DIRT);
+
+        // Check that the chunk now exists
+        Chunk newChunk = world.getChunk(chunkX, chunkY, chunkZ);
+        Assertions.assertNotNull(newChunk,
+            "Chunk at (" + chunkX + "," + chunkY + "," + chunkZ + ") should exist after setting voxel far away.");
+
+        // Also check if the isDirty flag was set on the new chunk (it should be, by setVoxel)
+        // This requires Chunk.isDirty to be accessible, or to test its effect (e.g. rebuildMesh is called)
+        // For now, we'll assume Chunk.setVoxel correctly sets its internal isDirty flag.
+        // We can also check the voxel type itself.
+        Voxel voxel = world.getVoxel(farX, farY, farZ);
+        Assertions.assertNotNull(voxel, "Voxel in newly created chunk should not be null.");
+        Assertions.assertEquals(Voxel.VoxelType.DIRT, voxel.type, "Voxel type in newly created chunk should be DIRT.");
+    }
+}


### PR DESCRIPTION
This commit introduces the foundational classes for game structure:

- Level: Contains Player and World objects, managing the overall game state.
- Player: Represents the player entity with a position.
- World: Manages a collection of Chunks and provides methods for world-coordinate voxel manipulation (get, set, clear). It now supports negative coordinates and dynamic chunk creation.
- Chunk: Modified to support individual voxel getting/setting, and includes a dirty flag mechanism to trigger mesh and data texture regeneration only when necessary.

The MyEngine class has been updated to use the Level class, and its camera is initialized based on the Player's starting position.

Basic unit tests for the World class have been added, covering voxel operations, negative coordinates, and chunk creation. These tests run in a headless LibGDX environment with GL calls mocked.